### PR TITLE
Fix audio track parser to split lines correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,8 +479,7 @@
           }
 
           const text = await response.text();
-          const lines = text.split(/
-/);
+          const lines = text.split(/\r?\n/);
           const parsed = [];
 
           lines.forEach((line, index) => {


### PR DESCRIPTION
## Summary
- split audio.txt content by newline characters instead of an empty regex so track parsing works as intended

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d11e8aba4c8329b711996db672710e